### PR TITLE
Bug Fix #33: Ensure token is set before comparison

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="ws_sdk",
-    version="0.5",
+    version="0.5.1",
     author="WhiteSource Professional Services",
     author_email="ps@whitesourcesoftware.com",
     description="WS Python SDK",

--- a/ws_sdk/web.py
+++ b/ws_sdk/web.py
@@ -389,7 +389,7 @@ class WS:
                 product['type'] = PRODUCT
                 product['org_token'] = self.token
 
-                if compare_digest(product['token'], token):
+                if token and compare_digest(product['token'], token):
                     logging.debug(f"Found searched token: {token}")
                     scopes.append(product)
                     return scopes                                              # TODO FIX THIS


### PR DESCRIPTION
Add a simple check to ensure the `token` parameter is set before comparing against the product token. This will fix #33 